### PR TITLE
Correct indentation in bundle 4

### DIFF
--- a/bundle4/bundle.yaml
+++ b/bundle4/bundle.yaml
@@ -1,7 +1,7 @@
 apiVersion: "1"
 id: "wroble4"
 description: "casc"
-version: "5"
+version: "6"
 jcasc:
   - "jenkins.yaml"
 plugins:

--- a/bundle4/items.yaml
+++ b/bundle4/items.yaml
@@ -21,13 +21,13 @@ items:
     attributes:
     - value: useDifferentAgents
       key: name
- - kind: cloudbeesTemplatedJob
-   catalog: cw-catalog
-   name: useSharedAgent
-   model: cw-catalog/useSharedAgent
-   attributes:
-   - value: useSharedAgent
-    key: name
+  - kind: cloudbeesTemplatedJob
+    catalog: cw-catalog
+    name: useSharedAgent
+    model: cw-catalog/useSharedAgent
+    attributes:
+    - value: useSharedAgent
+      key: name
   properties:
   - envVars: {}
   - itemRestrictions:


### PR DESCRIPTION
CasC validation was failing for bundle 4 with:

```
RawBundle /var/jenkins_home/tmp-fa3b819b-ba03-438b-a501-e1211c0f9340/main/bundle4 cannot be read.
while parsing a block mapping
 in 'string', line 1, column 1:
    removeStrategy:
    ^
expected <block end>, but found '<block sequence start>'
 in 'string', line 24, column 2:
     - kind: cloudbeesTemplatedJob
     ^

	at org.yaml.snakeyaml.parser.ParserImpl$ParseBlockMappingKey.produce(ParserImpl.java:679)
```

After this fix, validation is successful:
<img width="1026" alt="Screenshot 2023-11-10 at 10 41 53 AM" src="https://github.com/poc-prep/cloud-config-bundle/assets/19917557/3e741fbc-09f2-40c8-967a-740659c984a6">


Tested on CloudBees CI Cloud Operations Center 2.414.3.8